### PR TITLE
remove sudo from default install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Find a suitable IP host to view local websites on.
 
 ## Command line
-Install it globally to use on the command line:
+Install it globally to use on the command line (use `sudo` only if necessary):
 
-`sudo npm install -g dev-ip`
+`npm install -g dev-ip`
 
 then run:
 


### PR DESCRIPTION
sudo by default can cause a lot of problems, and most systems by default don't require it.
I nearly pasted in sudo, and caught it before causing myself a permission headache. 
Hopefully this PR will save others from that fate.
