### PR TITLE
Switch to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "engines": {
     "node": ">= 0.8.0"
   },
+  "files": ["lib/dev-ip.js"],
   "scripts": {
     "lint": "jshint lib/*.js test/*.js",
     "unit": "mocha",


### PR DESCRIPTION
Prevent all file from being published to npm.

Before:
```
npm notice 📦  dev-ip@1.0.1
npm notice === Tarball Contents === 
npm notice 436B  .jshintrc                     
npm notice 526B  test/.jshintrc                
npm notice 1.1kB LICENSE-MIT                   
npm notice 886B  lib/dev-ip.js                 
npm notice 2.2kB test/devip.js                 
npm notice 72B   example.js                    
npm notice 725B  test/fixtures/resp-multiple.js
npm notice 358B  test/fixtures/resp-none.js    
npm notice 610B  test/fixtures/resp-single.js  
npm notice 958B  package.json                  
npm notice 825B  README.md                     
npm notice 77B   .travis.yml                   
npm notice === Tarball Details === 
npm notice name:          dev-ip                                  
npm notice version:       1.0.1                                   
npm notice package size:  3.2 kB                                  
npm notice unpacked size: 8.7 kB                                  
npm notice shasum:        77567e4a9d957fd72658b264b074e271ea22467f
npm notice integrity:     sha512-qh3LykupmL86H[...]JqpOkHvdZluqA==
npm notice total files:   12    

```
After:
```
npm notice 📦  dev-ip@1.0.1
npm notice === Tarball Contents === 
npm notice 886B lib/dev-ip.js
npm notice 988B package.json 
npm notice 825B README.md    
npm notice === Tarball Details === 
npm notice name:          dev-ip                                  
npm notice version:       1.0.1                                   
npm notice package size:  1.4 kB                                  
npm notice unpacked size: 2.7 kB                                  
npm notice shasum:        3daf3691c2ade35a185a95a8eb60139972ac6115
npm notice integrity:     sha512-4+HAXG/0K3N8q[...]pGj/vyXy1rpjA==
npm notice total files:   3    
```